### PR TITLE
added kcc configs for basic cluster with GMP enabled

### DIFF
--- a/gmp-with-kcc/gke.yaml
+++ b/gmp-with-kcc/gke.yaml
@@ -1,0 +1,36 @@
+apiVersion: container.cnrm.cloud.google.com/v1beta1
+kind: ContainerCluster
+metadata:
+  labels:
+    availability: dev
+    target-audience: development
+  name: gmp-enabled-cluster
+spec:
+  description: A GMP enabled cluster
+  location: northamerica-northeast1-a
+  initialNodeCount: 1
+  networkingMode: ROUTES
+  clusterIpv4Cidr: 10.96.0.0/14
+  masterAuthorizedNetworksConfig:
+    cidrBlocks:
+      - displayName: Trusted external network
+        cidrBlock: 10.2.0.0/16
+  addonsConfig:
+    gcePersistentDiskCsiDriverConfig:
+      enabled: true
+    horizontalPodAutoscaling:
+      disabled: true
+    httpLoadBalancing:
+      disabled: false
+  loggingConfig:
+    enableComponents:
+      - "SYSTEM_COMPONENTS"
+      - "WORKLOADS"
+  monitoringConfig:
+    enableComponents:
+      - "SYSTEM_COMPONENTS"
+    managedPrometheus:
+      enabled: true
+  workloadIdentityConfig:
+    # Replace ${PROJECT_ID?} with your project ID.
+    workloadPool: "${PROJECT_ID?}.svc.id.goog"


### PR DESCRIPTION
Here's the configs for a KCC deployed GKE cluster with Managed Prometheus enabled. Let me know if you need it in a different format or want a README on getting Config Connector setup as well.